### PR TITLE
(Refactor) Add save/load dialogs for diagram loading and saving

### DIFF
--- a/UMLEditor/UMLEditor/Views/MainWindow.axaml
+++ b/UMLEditor/UMLEditor/Views/MainWindow.axaml
@@ -129,17 +129,19 @@
                                 Click="ExitB_OnClick"
                                 Content="Exit"/>
                         
-                        <Button Grid.Row="1" 
+                        <Button Name="SaveDiagramButton"
+                                Grid.Row="1" 
                                 Grid.Column="0" 
                                 Width="375"
                                 Click="SaveButtonOnClick"
-                                Content="Save"/>
+                                Content="Save Diagram"/>
                         
-                        <Button Grid.Row="1" 
+                        <Button Name="LoadDiagramButton"
+                                Grid.Row="1" 
                                 Grid.Column="1" 
                                 Width="375"
                                 Click="LoadButton_OnClick"
-                                Content="Load"/>
+                                Content="Load Diagram"/>
                                 
                 </Grid>
                 

--- a/UMLEditor/UMLEditor/Views/MainWindow.axaml.cs
+++ b/UMLEditor/UMLEditor/Views/MainWindow.axaml.cs
@@ -41,15 +41,6 @@ namespace UMLEditor.Views
             LoadDiagramButton = this.FindControl<Button>("LoadDiagramButton");
             InitFileDialogs(out OpenDialog, out SaveDialog, new []{ "json" });
             
-            // MATTHEW & CJ adding a new class should be as simple as this, just remember to add input verification.
-            
-             ActiveDiagram.Classes.Add(new Class("HELLO"));
-             ActiveDiagram.Classes.Add(new Class("WORLD"));
-             
-             Class CurrentClass = ActiveDiagram.GetClassByName("HELLO");
-             CurrentClass.Attributes.Add(new AttributeObject("Test"));
-             CurrentClass.Attributes.Add(new AttributeObject("Test2"));
-
         }
 
         private void InitializeComponent()


### PR DESCRIPTION
The save and load buttons now use the operating system's file dialog. This should address the user friendliness issues that have been raised previously. 