### PR TITLE
Disabled diagram changed event notification

### DIFF
--- a/UMLEditor/UMLEditor.NetCore/Program.cs
+++ b/UMLEditor/UMLEditor.NetCore/Program.cs
@@ -14,10 +14,8 @@ namespace UMLEditor.NetCore
         [STAThread]
         public static void Main(string[] args)
         {
-            int counter = 0;
             Diagram.DiagramChanged += (sender, _) =>
             {
-                Console.WriteLine($"Diagram Changed {counter++}");
                 TimeMachine.AddState((Diagram)sender!);
             };
             // Ensure at least one arg is provided


### PR DESCRIPTION
Disabled the "Diagram changed \#" notification written to the console when the changed event is fired. 