### PR TITLE
Fixed classbox bug from last commit

### DIFF
--- a/UMLEditor/UMLEditor/Views/CustomControls/RelationshipLine.cs
+++ b/UMLEditor/UMLEditor/Views/CustomControls/RelationshipLine.cs
@@ -386,10 +386,13 @@ public class RelationshipLine
             {
                 Point newPos = shortestPath.Pop().Center;
                 _gridPoints.Add(newPos);
-                newLine = CreateRelationshipLine(pos, newPos);
-                Segments.Add(newLine);
-                myCanvas.Children.Add(newLine);
-                pos = newPos;
+                if (shortestPath.Count % 2 == 0)
+                {
+                    newLine = CreateRelationshipLine(pos, newPos);
+                    Segments.Add(newLine);
+                    myCanvas.Children.Add(newLine);
+                    pos = newPos;
+                }
             }
 
             _gridPoints.Add(_closestPair.End);

--- a/UMLEditor/UMLEditor/Views/MainWindow.axaml.cs
+++ b/UMLEditor/UMLEditor/Views/MainWindow.axaml.cs
@@ -32,7 +32,6 @@ namespace UMLEditor.Views
     {
 
         private Diagram _activeDiagram;
-        private List<ClassBox> _classBoxes;
 
         private List<ClassBox> DrawnClassBoxes
         {
@@ -116,7 +115,6 @@ namespace UMLEditor.Views
             
             _activeDiagram = new Diagram();
 
-            _classBoxes = new List<ClassBox>();
             _activeFile = new JSONDiagramFile();
 
             InitFileDialogs(out _openFileDialog, out _saveFileDialog, "json");
@@ -740,7 +738,6 @@ namespace UMLEditor.Views
             {
                 
                 ClassBox newClass = new ClassBox(currentClassName, ref _activeDiagram, this, _inEditMode);
-                _classBoxes.Add(newClass);
                 _canvas.Children.Add(newClass);
                 ClassBoxes.RegisterClassBox(newClass);
                 
@@ -758,7 +755,6 @@ namespace UMLEditor.Views
             {
                 
                 ClassBox newClass = new ClassBox(currentClass, ref _activeDiagram, this, _inEditMode);
-                _classBoxes.Add(newClass);
                 _canvas.Children.Add(newClass);
                 ClassBoxes.RegisterClassBox(newClass);
                 
@@ -774,7 +770,8 @@ namespace UMLEditor.Views
         {
             _relationshipLines.Clear();
             RelationshipLine.ResetGrid();
-            foreach (ClassBox c in _classBoxes)
+            List<ClassBox> classBoxes = ClassBoxes.ClassBoxList;
+            foreach (ClassBox c in classBoxes)
             {
                 AddClassBoxToGrid(c);
             }

--- a/UMLEditor/UMLEditor/Views/Managers/ClassBoxes.cs
+++ b/UMLEditor/UMLEditor/Views/Managers/ClassBoxes.cs
@@ -16,6 +16,23 @@ public static class ClassBoxes
     private static readonly Dictionary<string, ClassBox> Register = new();
 
     /// <summary>
+    /// Public accessor for the list of ClassBoxes from Register
+    /// </summary>
+    public static List<ClassBox> ClassBoxList
+    {
+        get
+        {
+            List<ClassBox> list = new();
+            foreach (var cb in Register)
+            {
+                list.Add(cb.Value);
+            }
+
+            return list;
+        }
+    }
+
+    /// <summary>
     /// Allows creating a new registration for a ClassBox
     /// </summary>
     /// <param name="toRegister">The ClassBox to register</param>


### PR DESCRIPTION
Changed line draw to use ClassBoxes.cs manager instead of a separate list, which fixed bug with the grid not refreshing. Also changed line draw to only connect every other point from the path, resulting in slightly better looking lines.